### PR TITLE
Null checks for user points

### DIFF
--- a/app/Model/User.php
+++ b/app/Model/User.php
@@ -277,7 +277,7 @@ class User
      */
     public function getGachapremium(): int
     {
-        return $this->gacha_premium;
+        return $this->gacha_premium ?? 0;
     }
     
     /**
@@ -296,7 +296,7 @@ class User
      */
     public function getGachatrial(): int
     {
-        return $this->gacha_trial;
+        return $this->gacha_trial ?? 0;
     }
     
     /**
@@ -315,7 +315,7 @@ class User
      */
     public function getFrontierpoints(): int
     {
-        return $this->frontier_points;
+        return $this->frontier_points ?? 0;
     }
     
     /**


### PR DESCRIPTION
Added null coalescing operators to resolve Issue #23

Tested and confirmed on my end. There may be other entries that need this protection, but I haven't run into other problems yet. More null checks/defenses never hurt though.